### PR TITLE
[fix] Fix top-level CUDAGraph export

### DIFF
--- a/python/foundry/__init__.py
+++ b/python/foundry/__init__.py
@@ -9,12 +9,13 @@ from .allocation_region import (
     resume_allocation_region,
     set_current_alloc_offset,
 )
+
+from .ops import *  # isort: skip
 from .graph import (
     CUDAGraph,
     graph,
     save_graph_manifest,
 )
-from .ops import *
 
 # Re-exports. Listed here so ruff's --fix doesn't strip them as unused.
 # (We also configure per-file-ignores for F401 in pyproject.toml as a backstop.)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -69,6 +69,13 @@ def test_re_exports_present():
     )
 
 
+def test_cudagraph_reexport_uses_python_wrapper():
+    foundry = importlib.import_module("foundry")
+    graph_module = importlib.import_module("foundry.graph")
+
+    assert foundry.CUDAGraph is graph_module.CUDAGraph
+
+
 def test_vllm_integration_public_api():
     mod = importlib.import_module("foundry.integration.vllm")
     for name in ("install_hooks", "CUDAGraphExtensionMode", "get_graph_extension_mode"):


### PR DESCRIPTION
## The bug

The top-level package imports the Python `CUDAGraph` wrapper and then applies `from .ops import *`. The native extension exports the same name. Its wildcard import therefore replaces the wrapper. As a result, `foundry.CUDAGraph` resolves to the raw binding instead of the documented Python wrapper.

## The fix

Import the native re-exports first, then explicitly re-export `foundry.graph.CUDAGraph`. Add a regression to the existing import test that checks the top-level name resolves to the Python wrapper.

## Test plan

- `pytest -q tests/test_imports.py::test_cudagraph_reexport_uses_python_wrapper`
- `ruff check python/foundry/__init__.py tests/test_imports.py`
- `ruff format --check python/foundry/__init__.py tests/test_imports.py`

The focused test passed in the built Linux environment. On one RTX 4090 Laptop GPU, the low-level SAVE oracle passed in 4.2557 seconds, n=1. The LOAD oracle passed in 2.3335 seconds, n=1.

I used AI assistance. I reviewed the change and can defend the implementation and verification.
